### PR TITLE
Fix recipe registration and some other bugfixes

### DIFF
--- a/MakeTea/Mug.cs
+++ b/MakeTea/Mug.cs
@@ -1,7 +1,6 @@
 ﻿using System.Linq;
 using Vintagestory.API.Common;
 using Vintagestory.GameContent;
-
 namespace MakeTea
 {
     internal class Mug : BlockLiquidContainerTopOpened

--- a/MakeTea/Mug.cs
+++ b/MakeTea/Mug.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Vintagestory.API.Common;
 using Vintagestory.GameContent;
+
 namespace MakeTea
 {
     internal class Mug : BlockLiquidContainerTopOpened

--- a/MakeTea/TeapotRecipe.cs
+++ b/MakeTea/TeapotRecipe.cs
@@ -336,20 +336,27 @@ namespace MakeTea
         {
             float outsize = 0;
             ItemStack[] stacks = slots.Select(s => s.Itemstack).ToArray();
-            if (craftingTime < Duration || !Matches(stacks, temperature, out outsize) || outsize == 0) return false;
+            if (craftingTime < Duration || !Matches(stacks, temperature, out outsize) || outsize == 0)
+                return false;
             for (var i = 0; i < slots.Count; i++)
             {
                 var quantity = Ingredients[i].Quantity;
                 var stack = slots[i].Itemstack;
-                var props = BlockLiquidContainerBase.GetContainableProps(stack);
-                if (props != null && props.ItemsPerLitre > 0)
+                if (stack == null) continue;
+
+                if (stack.Collectible.IsLiquid())
                 {
+                    WaterTightContainableProps props = BlockLiquidContainerBase.GetContainableProps(slots[i].Itemstack);
                     quantity = (int)(props.ItemsPerLitre * Ingredients[i].Quantity);
                 }
-                stack.StackSize -= (int)MathF.Round(quantity * outsize);
-                if (stack.StackSize == 0)
+
+                int consume = (int)MathF.Round((float)quantity * outsize);
+                stack.StackSize -= consume;
+
+                if (stack.StackSize <= 0)
+                {
                     slots[i].Itemstack = null;
-                slots[i].MarkDirty();
+                }
             }
             var outputStack = Output.ResolvedItemstack.Clone();
             outputStack.StackSize = (int)(Output.Litres * BlockLiquidContainerBase.GetContainableProps(outputStack).ItemsPerLitre * outsize);


### PR DESCRIPTION
Fixes recipes registration, recipes are now properly registered in assets finalized.
Properly loads multiple recipes with the same output
Fixes a bug with temperature being lost on reloading a save.
Fixes a bug with teapot needing to be emptied if it has contents and your reload a world
(tea pot still doesn't pick up progressing on reload, but it just needs to be removed from fire and put back in and progress will pick back up at the same spot which is better than it getting locked up entirely and needing to be emptied)
