### PR TITLE
feat: support any BlockLiquidContainerBase for stability gain

### DIFF
--- a/MakeTea/BlockLiquidContainerBasePatch.cs
+++ b/MakeTea/BlockLiquidContainerBasePatch.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Reflection;
 using HarmonyLib;
@@ -62,7 +63,7 @@ public class BlockLiquidContainerBasePatch
         var stabilityBehavior = byEntity.GetBehavior<EntityBehaviorTemporalStabilityAffected>();
         if (stabilityBehavior == null) return;
 
-        var stabilityGainTotal = stabilityGain * consumedSize * (1f - spoilState) / containableProps.ItemsPerLitre;
+        var stabilityGainTotal = stabilityGain * consumedSize * Math.Max(0.0f, 1f - spoilState) / containableProps.ItemsPerLitre;
         // api.Logger.Debug(
         //     "MakeTeaMod: entity [{0}] with stability {1:F3}, gain +{2:F3} stability using [{3}] liquid ({4:P1} spoiled) from container [{5}]",
         //     byEntity.GetName(), stabilityBehavior.OwnStability, stabilityGainTotal, __state.ContentStack.GetName(),

--- a/MakeTea/BlockLiquidContainerBasePatch.cs
+++ b/MakeTea/BlockLiquidContainerBasePatch.cs
@@ -63,10 +63,10 @@ public class BlockLiquidContainerBasePatch
         if (stabilityBehavior == null) return;
 
         var stabilityGainTotal = stabilityGain * consumedSize * (1f - spoilState) / containableProps.ItemsPerLitre;
-        api.Logger.Debug(
-            "MakeTeaMod: entity [{0}] with stability {1:F3}, gain +{2:F3} stability using [{3}] liquid ({4:P1} spoiled) from container [{5}]",
-            byEntity.GetName(), stabilityBehavior.OwnStability, stabilityGainTotal, __state.ContentStack.GetName(),
-            spoilState, slot.Itemstack.GetName());
+        // api.Logger.Debug(
+        //     "MakeTeaMod: entity [{0}] with stability {1:F3}, gain +{2:F3} stability using [{3}] liquid ({4:P1} spoiled) from container [{5}]",
+        //     byEntity.GetName(), stabilityBehavior.OwnStability, stabilityGainTotal, __state.ContentStack.GetName(),
+        //     spoilState, slot.Itemstack.GetName());
 
         stabilityBehavior.OwnStability += stabilityGainTotal;
     }

--- a/MakeTea/BlockLiquidContainerBasePatch.cs
+++ b/MakeTea/BlockLiquidContainerBasePatch.cs
@@ -1,0 +1,79 @@
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using Vintagestory.API.Common;
+using Vintagestory.GameContent;
+
+namespace MakeTea;
+
+// Useful article: https://harmony.pardeike.net/articles/patching-prefix.html
+[HarmonyPatch(typeof(BlockLiquidContainerBase), "tryEatStop")]
+public class BlockLiquidContainerBasePatch
+{
+    [HarmonyPrefix]
+    public static void TryEatStopPrefix(
+        BlockLiquidContainerBase __instance, out TryEatStopState __state,
+        float secondsUsed, ItemSlot slot, EntityAgent byEntity)
+    {
+        __state = new TryEatStopState();
+
+        if (slot.Itemstack == null) return;
+
+        var handle = true;
+        handle &= slot.Itemstack != null;
+        var contentStack = __instance.GetContent(slot.Itemstack);
+        handle = handle && contentStack != null && contentStack.StackSize > 0;
+        handle = handle && (contentStack.Item?.WildCardMatch("teaportion-*") ?? false);
+        handle = handle && contentStack.Item.Attributes["makeTeaPortionProps"].Exists;
+        handle = handle && byEntity.HasBehavior<EntityBehaviorTemporalStabilityAffected>();
+
+        if (handle)
+        {
+            __state.OldSize = contentStack?.StackSize ?? 0;
+            __state.ContentStack = contentStack;
+        }
+    }
+
+    [HarmonyPostfix]
+    public static void TryEatStopPostfix(
+        BlockLiquidContainerBase __instance, TryEatStopState __state,
+        float secondsUsed, ItemSlot slot, EntityAgent byEntity)
+    {
+        if (__state.OldSize <= 0 || __state.ContentStack == null || slot.Itemstack == null) return;
+
+        var consumedSize = __state.OldSize - (__instance.GetContent(slot.Itemstack)?.StackSize ?? 0);
+        if (consumedSize <= 0) return;
+
+        var dummySlot = typeof(BlockLiquidContainerBase)
+            .GetMethod("GetContentInDummySlot", BindingFlags.Instance | BindingFlags.NonPublic)?
+            .Invoke(__instance, [slot, __state.ContentStack]) as ItemSlot;
+        var api = typeof(BlockLiquidContainerBase)
+            .GetField("api", BindingFlags.Instance | BindingFlags.NonPublic)?
+            .GetValue(__instance) as ICoreAPI;
+
+        if (api == null) return;
+
+        var states = __state.ContentStack.Collectible.UpdateAndGetTransitionStates(api.World, dummySlot);
+        var spoilState = states.FirstOrDefault(s => s.Props.Type == EnumTransitionType.Perish)?.TransitionLevel ?? 0f;
+        var containableProps = BlockLiquidContainerBase.GetContainableProps(__state.ContentStack);
+        if (containableProps == null) return;
+
+        var stabilityGain = __state.ContentStack.Item.Attributes["makeTeaPortionProps"]["stabilityGain"].AsFloat();
+        var stabilityBehavior = byEntity.GetBehavior<EntityBehaviorTemporalStabilityAffected>();
+        if (stabilityBehavior == null) return;
+
+        var stabilityGainTotal = stabilityGain * consumedSize * (1f - spoilState) / containableProps.ItemsPerLitre;
+        api.Logger.Debug(
+            "MakeTeaMod: entity [{0}] with stability {1:F3}, gain +{2:F3} stability using [{3}] liquid ({4:P1} spoiled) from container [{5}]",
+            byEntity.GetName(), stabilityBehavior.OwnStability, stabilityGainTotal, __state.ContentStack.GetName(),
+            spoilState, slot.Itemstack.GetName());
+
+        stabilityBehavior.OwnStability += stabilityGainTotal;
+    }
+
+    public class TryEatStopState
+    {
+        public ItemStack ContentStack;
+        public int OldSize;
+    }
+}

--- a/MakeTea/Mug.cs
+++ b/MakeTea/Mug.cs
@@ -6,7 +6,6 @@ namespace MakeTea
 {
     internal class Mug : BlockLiquidContainerTopOpened
     {
-
         public override int GetMergableQuantity(ItemStack sinkStack, ItemStack sourceStack, EnumMergePriority priority)
         {
             if (priority == EnumMergePriority.AutoMerge || priority == EnumMergePriority.DirectMerge)
@@ -25,33 +24,6 @@ namespace MakeTea
             }
 
             return base.GetMergableQuantity(sinkStack, sourceStack, priority);
-        }
-
-        protected override void tryEatStop(float secondsUsed, ItemSlot slot, EntityAgent byEntity)
-        {
-            bool handle = true;
-            handle &= slot.Itemstack != null;
-            var contentStack = GetContent(slot.Itemstack);
-            handle = handle && contentStack != null && contentStack.StackSize > 0;
-            handle = handle && (contentStack.Item?.WildCardMatch("teaportion-*") ?? false);
-            handle = handle && (contentStack.Item.Attributes["makeTeaPortionProps"].Exists);
-            handle = handle && byEntity.HasBehavior<EntityBehaviorTemporalStabilityAffected>();
-            var oldSize = contentStack?.StackSize ?? 0;
-            base.tryEatStop(secondsUsed, slot, byEntity);
-            var newContent = GetContent(slot.Itemstack);
-            var consumedSize = oldSize - (newContent?.StackSize ?? 0);
-            if (handle && consumedSize > 0)
-            {
-                ItemSlot dummySlot = GetContentInDummySlot(slot, contentStack);
-                var states = contentStack.Collectible.UpdateAndGetTransitionStates(api.World, dummySlot);
-                // TODO: The way base.tryEatStop reads spoilstate seems not to respect liquids?? Verify and bug report
-                var spoilState = states.FirstOrDefault(s => s.Props.Type == EnumTransitionType.Perish)?.TransitionLevel ?? 0f;
-                WaterTightContainableProps containableProps = GetContainableProps(contentStack);;
-                var stabilityGain = contentStack.Item.Attributes["makeTeaPortionProps"]["stabilityGain"].AsFloat();
-                var stabilityBehavior = byEntity.GetBehavior<EntityBehaviorTemporalStabilityAffected>();
-                stabilityBehavior.OwnStability += stabilityGain * consumedSize * (1f - spoilState) / containableProps.ItemsPerLitre;
-
-            }
         }
     }
 }

--- a/MakeTea/Teapot.cs
+++ b/MakeTea/Teapot.cs
@@ -31,10 +31,6 @@ namespace MakeTea
             return api.World.Calendar.TotalHours;
         }
 
-
-
-
-
         public override void OnLoaded(ICoreAPI api)
         {
             base.OnLoaded(api);
@@ -230,36 +226,6 @@ namespace MakeTea
             if (byEntity.Controls.ShiftKey) return false; // block “use” only while sneaking
             return base.OnHeldInteractStep(secondsUsed, slot, byEntity, blockSel, entitySel);
         }
-
-
-        protected override void tryEatStop(float secondsUsed, ItemSlot slot, EntityAgent byEntity)
-        {
-            bool handle = true;
-            handle &= slot.Itemstack != null;
-            var contentStack = GetContent(slot.Itemstack);
-            handle = handle && contentStack != null && contentStack.StackSize > 0;
-            handle = handle && (contentStack.Item?.WildCardMatch("teaportion-*") ?? false);
-            handle = handle && (contentStack.Item.Attributes["makeTeaPortionProps"].Exists);
-            handle = handle && byEntity.HasBehavior<EntityBehaviorTemporalStabilityAffected>();
-            var oldSize = contentStack?.StackSize ?? 0;
-            base.tryEatStop(secondsUsed, slot, byEntity);
-            var newContent = GetContent(slot.Itemstack);
-            var consumedSize = oldSize - (newContent?.StackSize ?? 0);
-            if (handle && consumedSize > 0)
-            {
-                ItemSlot dummySlot = GetContentInDummySlot(slot, contentStack);
-                var states = contentStack.Collectible.UpdateAndGetTransitionStates(api.World, dummySlot);
-                // TODO: The way base.tryEatStop reads spoilstate seems not to respect liquids?? Verify and bug report
-                var spoilState = states.FirstOrDefault(s => s.Props.Type == EnumTransitionType.Perish)?.TransitionLevel ?? 0f;
-                WaterTightContainableProps containableProps = GetContainableProps(contentStack); ;
-                var stabilityGain = contentStack.Item.Attributes["makeTeaPortionProps"]["stabilityGain"].AsFloat();
-                var stabilityBehavior = byEntity.GetBehavior<EntityBehaviorTemporalStabilityAffected>();
-                stabilityBehavior.OwnStability += stabilityGain * consumedSize * (1f - spoilState) / containableProps.ItemsPerLitre;
-
-            }
-        }
-
-
 
         public override bool OnBlockInteractStart(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel)
         {


### PR DESCRIPTION
Finally - something **everyone*** was waiting for - you can now chug catmint tea directly from buckets and gain temporal stability!

_(* OK, fine, one person in comments and I did)_

### Changes, in order of significance:
- added `BlockLiquidContainerBasePatch` class with Harmony patches for `BlockLiquidContainerBase.tryEatStop` method, which goes like this:
    - prefix patch `TryEatStopPrefix` is applied, checking if we are handling valid item stack (same logic as before) and saving current (i.e. before stack is split and consumed) tea stack size,
    - original `tryEatStop` method is executed normally
    - postfix patch `TryEatStopPostfix` is applied (or skipped if not valid), checking the item stack for attributes and applying custom logic (i.e. stability gain)
        - major difference here is using reflection for resolving protected methods and fields from `BlockLiquidContainerBase`
- `Mug` and `Teapot` classes no longer override `tryEatStop` method (which is now handled by Harmony patches)
- removed `// TODO: The way base.tryEatStop reads spoilstate seems not to respect liquids?? Verify and bug report` comment as it does not seem to apply anymore (spoil% is correctly applied to stability gain)
- some null checks here and there (now as we patch all `tryEatStop` we should be more careful not to break anything)
- minor code clean up in modified files

Tested locally on `v1.22.3` with vanilla liquid containers.